### PR TITLE
replace deprecated encode method in Ruby 3.0

### DIFF
--- a/lib/signrequest_client/api_client.rb
+++ b/lib/signrequest_client/api_client.rb
@@ -264,7 +264,7 @@ module SignRequestClient
     def build_request_url(path)
       # Add leading and trailing slashes to path
       path = "/#{path}".gsub(/\/+/, '/')
-      URI.encode(@config.base_url + path)
+      URI::DEFAULT_PARSER.escape(@config.base_url + path)
     end
 
     # Builds the HTTP request body

--- a/lib/signrequest_client/configuration.rb
+++ b/lib/signrequest_client/configuration.rb
@@ -175,7 +175,7 @@ module SignRequestClient
 
     def base_url
       url = "#{scheme}://#{[host, base_path].join('/').gsub(/\/+/, '/')}".sub(/\/+\z/, '')
-      URI.encode(url)
+      URI::DEFAULT_PARSER.escape(url)
     end
 
     # Gets API key (with prefix if set).


### PR DESCRIPTION
Temporary fix (hopefully, until the gem gets an update...?)
`URI.encode` method deprecated in Ruby 3.0, replaced w/ `URI::DEFAULT_PARSER.escape`